### PR TITLE
Use Getopt::Long with recommended options

### DIFF
--- a/scripts/es-alias-manager.pl
+++ b/scripts/es-alias-manager.pl
@@ -12,7 +12,7 @@ BEGIN {
 use DateTime;
 use Elasticsearch::Compat;
 use YAML;
-use Getopt::Long;
+use Getopt::Long qw(:config posix_default no_ignore_case no_ignore_case_always);
 use Pod::Usage;
 use App::ElasticSearch::Utilities qw(:all);
 

--- a/scripts/es-apply-settings.pl
+++ b/scripts/es-apply-settings.pl
@@ -13,7 +13,7 @@ use DateTime;
 use Elasticsearch::Compat;
 use JSON;
 use LWP::Simple;
-use Getopt::Long;
+use Getopt::Long qw(:config posix_default no_ignore_case no_ignore_case_always);
 use Pod::Usage;
 use App::ElasticSearch::Utilities qw(:all);
 

--- a/scripts/es-copy-index.pl
+++ b/scripts/es-copy-index.pl
@@ -15,7 +15,7 @@ use Elasticsearch::Compat;
 use File::Basename;
 use File::Spec;
 use FindBin;
-use Getopt::Long;
+use Getopt::Long qw(:config posix_default no_ignore_case no_ignore_case_always);
 use MIME::Lite;
 use Pod::Usage;
 use Sys::Hostname;

--- a/scripts/es-daily-index-maintenance.pl
+++ b/scripts/es-daily-index-maintenance.pl
@@ -13,7 +13,7 @@ use DateTime;
 use Elasticsearch::Compat;
 use JSON;
 use LWP::Simple;
-use Getopt::Long;
+use Getopt::Long qw(:config posix_default no_ignore_case no_ignore_case_always);
 use Pod::Usage;
 use App::ElasticSearch::Utilities qw(:all);
 

--- a/scripts/es-metrics-to-graphite.pl
+++ b/scripts/es-metrics-to-graphite.pl
@@ -11,7 +11,7 @@ BEGIN {
 use App::ElasticSearch::Utilities qw(:all);
 use Elasticsearch::Compat;
 use IO::Socket::INET;
-use Getopt::Long;
+use Getopt::Long qw(:config posix_default no_ignore_case no_ignore_case_always);
 use Pod::Usage;
 
 #------------------------------------------------------------------------#

--- a/scripts/es-nagios-check.pl
+++ b/scripts/es-nagios-check.pl
@@ -6,7 +6,7 @@ use strict;
 use LWP::Simple;
 use JSON;
 use Pod::Usage;
-use Getopt::Long;
+use Getopt::Long qw(:config posix_default no_ignore_case no_ignore_case_always);
 
 BEGIN {
     delete $ENV{$_} for qw{http_proxy};

--- a/scripts/es-search.pl
+++ b/scripts/es-search.pl
@@ -11,7 +11,7 @@ use Elasticsearch::Compat;
 use File::Basename;
 use File::Spec;
 use FindBin;
-use Getopt::Long;
+use Getopt::Long qw(:config posix_default no_ignore_case no_ignore_case_always);
 use JSON::XS;
 use MIME::Lite;
 use Pod::Usage;

--- a/scripts/es-status.pl
+++ b/scripts/es-status.pl
@@ -15,7 +15,7 @@ use IPC::Run3;
 use LWP::Simple;
 use File::Spec;
 use Term::ANSIColor;
-use Getopt::Long;
+use Getopt::Long qw(:config posix_default no_ignore_case no_ignore_case_always);
 use Pod::Usage;
 
 #------------------------------------------------------------------------#

--- a/scripts/es-storage-data.pl
+++ b/scripts/es-storage-data.pl
@@ -14,7 +14,7 @@ use DateTime;
 use Elasticsearch::Compat;
 use JSON;
 use LWP::Simple;
-use Getopt::Long;
+use Getopt::Long qw(:config posix_default no_ignore_case no_ignore_case_always);
 use Pod::Usage;
 use App::ElasticSearch::Utilities qw(:all);
 


### PR DESCRIPTION
Hi,

I tried to use `es-nagios-check.pl` with -H option, but it didn't work.
It seems that -H is recognized as --help like this:

```
$ perl scripts/es-nagios-check.pl -H [host]
Usage:
    es-nagios-check.pl -H [host] [options]
```

I think this is caused by default settings of `Getopt::Long`. I strongly recommend adding some configurations like this commit when we use Getopt::Long (See details in perldoc Getopt::Long).

After applying this patch, it works well.

```
$ perl scripts/es-nagios-check.pl -H [host]
ok: FETCH_HEALTH, HEALTH
```

I really appreciated if you would merge this PR.
Thanks.
