### PR TITLE
Prevent passing undef mappings

### DIFF
--- a/scripts/es-copy-index.pl
+++ b/scripts/es-copy-index.pl
@@ -125,7 +125,7 @@ unless( exists $OPT{append} ) {
         index => $INDEX{to},
         body  => {
             settings => $to_settings,
-            mappings => $mappings,
+            defined $mappings ? (mappings => $mappings) : (),
         }
     );
 


### PR DESCRIPTION
Original index may not have any mappings, in that case undef will be passed, which would lead to error
```
Failed to create index in ... (http status = 500): [
   "500",
   {
      "error" : "NullPointerException[null]",
      "status" : 500
   }
]
```