### PR TITLE
fix es-copy-index.pl when `--mapping` is not given.

### DIFF
--- a/scripts/es-copy-index.pl
+++ b/scripts/es-copy-index.pl
@@ -118,6 +118,7 @@ unless( exists $OPT{append} ) {
         };
     }
     else {
+        $res = es_request($ES{from}, '_mappings', {index => $INDEX{from}});
         $mappings = $res->{$INDEX{from}}{mappings};
     }
 


### PR DESCRIPTION
When `--mapping` is not given, the process to retrieve current
index mapping was wrong and retrive a blank hash instead. So
this was broken:

    es-copy-index --from es-01 --to es-02 --source log.20160323

This commit does an additional query for mapping when
`--mapping` is not given.