### PR TITLE
Move the scroll_id to the body of the request so that the id is not URL encoded

### DIFF
--- a/scripts/es-search.pl
+++ b/scripts/es-search.pl
@@ -359,9 +359,9 @@ AGES: while( !$DONE && @AGES ) {
         $start = time;
         $result = es_request('_search/scroll', {
             uri_param => {
-                scroll_id => $result->{_scroll_id},
                 scroll    => $q->scroll,
-            }
+            },
+            body => $result->{_scroll_id},
         });
         $duration += time - $start;
         last unless $result->{hits} && $result->{hits}{hits} && @{ $result->{hits}{hits} } > 0


### PR DESCRIPTION
We have started seeing scroll ids with '=' characters. These are getting encoded on the url
resulting in the scroll_id lookup on the server side failing. The documentation for ES shows
the scroll_id being supported as a body parameter.

WARNING: This will break scrolling with the current version of Elastijk, which assumes that all body content needs to be JSON encoded. In the case of the scroll parameter, this is not the case.  This commit and release needs to be coordinated with an appropriate update to Elastijk.