### PR TITLE
Fix authentication when ElasticSearch requires Kerberos auth

### DIFF
--- a/lib/App/ElasticSearch/Utilities/Connection.pm
+++ b/lib/App/ElasticSearch/Utilities/Connection.pm
@@ -237,7 +237,7 @@ sub request {
     my $req = App::ElasticSearch::Utilities::HTTPRequest->new( $method => $uri->as_string );
     $req->content($body) if defined $body;
 
-    return $self->ua->simple_request( $req );
+    return $self->ua->request( $req );
 }
 
 


### PR DESCRIPTION
simple_request does not handle authentication responses, which breaks
in environments where ElasticSearch requires Kerberos authentication.
