### PR TITLE
For es-search.pl allow _id to be shown as a column when using --show …

### DIFF
--- a/scripts/es-search.pl
+++ b/scripts/es-search.pl
@@ -511,6 +511,12 @@ AGES: while( !$DONE && @AGES ) {
             $last_hit_ts = $hit->{_source}{$CONFIG{timestamp}};
             $last_batch_id{$hit->{_id}}=1;
             my $record = {};
+
+            # Add the _id field to the source so that it is listed
+            # when showing full records and can be and can be
+            # used in @SHOW
+            $hit->{_source}->{_id} = $hit->{_id} unless defined($hit->{_source}->{_id});
+
             if( @SHOW ) {
                 my $flat = es_flatten_hash( $hit->{_source} );
                 debug_var($flat);


### PR DESCRIPTION
It is often useful to be able to list the _id field for elasticsearch records, but it is not showing up with es-search.pl since it is not in the source section of the record.  I copied the _id from the results into the source so that it shows up when passing "--show _id" to es-search.pl.  _id also shows up now when not passing any --show option.