### PR TITLE
Version 8.6

### DIFF
--- a/CopyIndexes.mkdn
+++ b/CopyIndexes.mkdn
@@ -4,7 +4,7 @@ es-copy-index.pl - Copy an index from one cluster to another
 
 # VERSION
 
-version 8.6
+version 8.7
 
 # SYNOPSIS
 
@@ -42,7 +42,6 @@ From App::ElasticSearch::Utilities:
     --index         Index to run commands against
     --base          For daily indexes, reference only those starting with "logstash"
                      (same as --pattern logstash-* or logstash-DATE)
-    --datesep       Date separator, default '.' also (--date-separator)
     --pattern       Use a pattern to operate on the indexes
     --days          If using a pattern or base, how many days back to go, default: 1
 

--- a/Maintenance.mkdn
+++ b/Maintenance.mkdn
@@ -4,7 +4,7 @@ es-daily-index-maintenance.pl - Run to prune old indexes and optimize existing
 
 # VERSION
 
-version 8.6
+version 8.7
 
 # SYNOPSIS
 
@@ -46,7 +46,6 @@ From App::ElasticSearch::Utilities:
     --index         Index to run commands against
     --base          For daily indexes, reference only those starting with "logstash"
                      (same as --pattern logstash-* or logstash-DATE)
-    --datesep       Date separator, default '.' also (--date-separator)
     --pattern       Use a pattern to operate on the indexes
     --days          If using a pattern or base, how many days back to go, default: 1
 

--- a/README.mkdn
+++ b/README.mkdn
@@ -4,7 +4,7 @@ App::ElasticSearch::Utilities - Utilities for Monitoring ElasticSearch
 
 # VERSION
 
-version 8.6
+version 8.7
 
 # SYNOPSIS
 
@@ -285,7 +285,6 @@ From App::ElasticSearch::Utilities:
     --index         Index to run commands against
     --base          For daily indexes, reference only those starting with "logstash"
                      (same as --pattern logstash-* or logstash-DATE)
-    --datesep       Date separator, default '.' also (--date-separator)
     --pattern       Use a pattern to operate on the indexes
     --days          If using a pattern or base, how many days back to go, default: 1
 

--- a/Searching.mkdn
+++ b/Searching.mkdn
@@ -4,7 +4,7 @@ es-search.pl - Provides a CLI for quick searches of data in ElasticSearch daily 
 
 # VERSION
 
-version 8.6
+version 8.7
 
 # SYNOPSIS
 
@@ -62,7 +62,6 @@ From App::ElasticSearch::Utilities:
     --index         Index to run commands against
     --base          For daily indexes, reference only those starting with "logstash"
                      (same as --pattern logstash-* or logstash-DATE)
-    --datesep       Date separator, default '.' also (--date-separator)
     --pattern       Use a pattern to operate on the indexes
     --days          If using a pattern or base, how many days back to go, default: 1
 

--- a/dist.ini
+++ b/dist.ini
@@ -70,6 +70,7 @@ fake_home = 1
 ; authordep Pod::Weaver::Section::Collect::FromOther
 ; authordep Pod::Elemental::Transformer::List
 ; authordep Test::Perl::Critic
+; authordep Perl::Critic::Nits
 
 ; Git stuff
 [Git::GatherDir]

--- a/lib/App/ElasticSearch/Utilities/Metrics.pm
+++ b/lib/App/ElasticSearch/Utilities/Metrics.pm
@@ -57,13 +57,13 @@ my @_IGNORES = qw(
 An array of metric names to ignore, in addition to the static list when parsing
 the `_node/_local/stats` stats.  Defaults to:
 
-    [qw(adaptive_selection)]
+    [qw(adaptive_selection discovery)]
 
 Plus ignores sections containing C<ingest>, C<ml>, C<transform> B<UNLESS> those
 roles appear in the node's roles.  Also, unless the node is tagged as a
 C<data*> node, the following keys are ignored:
 
-    [qw(force_merge merges pressure recovery segments translog)]
+    [qw(force_merge indexing indices merges pressure recovery segments translog)]
 
 =cut
 
@@ -74,7 +74,7 @@ has 'ignore' => (
         my ($self) = @_;
 
         my %roles = map { $_ => 1 } @{ $self->node_details->{roles} };
-        my @ignore = qw(adaptive_selection);
+        my @ignore = qw(adaptive_selection discovery);
 
         # Easy roles and sections are the same
         foreach my $section ( qw(ingest ml transform) ) {
@@ -82,9 +82,13 @@ has 'ignore' => (
                 unless $roles{$section};
         }
 
+        if( ! $roles{ml} ) {
+            push @ignore, qw(ml_datafeed ml_job_comms ml_utility);
+        }
+
         # Skip some sections if we're not a data node
         if( ! grep { /^data/ } keys %roles ) {
-            push @ignore, qw(force_merge merges pressure recovery segments translog);
+            push @ignore, qw(force_merge indexing indices merges pressure recovery segments translog);
         }
 
         return \@ignore;

--- a/lib/App/ElasticSearch/Utilities/Metrics.pm
+++ b/lib/App/ElasticSearch/Utilities/Metrics.pm
@@ -91,6 +91,9 @@ sub _build_node_details {
             }
         }
     }
+
+    # Fail our type check
+    return;
 }
 
 =attr node_id
@@ -111,8 +114,11 @@ sub _build_node_id {
         return $details->{id};
     }
 
-    die sprintf "unable to determine node_id for %s:%d",
+    warn sprintf "unable to determine node_id for %s:%d",
         $self->host, $self->port;
+
+    # Fail our type check
+    return;
 }
 
 =attr with_cluster_metrics
@@ -186,6 +192,9 @@ sub collect_node_metrics {
     if( my $res = $self->request('_nodes/_local/stats')->content ) {
         return $self->_stat_collector( $res->{nodes}{$self->node_id} );
     }
+
+    # Explicit return of empty list
+    return;
 }
 
 =method collect_cluster_metrics()
@@ -244,6 +253,8 @@ sub _collect_index_blocks {
         return map { { key => "cluster.$_", value => $collected{$_} } } sort keys %collected;
     }
 
+    # Explicit return of empty list
+    return;
 }
 
 =method collect_index_metrics()

--- a/scripts/es-daily-index-maintenance.pl
+++ b/scripts/es-daily-index-maintenance.pl
@@ -28,7 +28,6 @@ GetOptions(\%opt,
     'optimize',
     'optimize-days=i',
     'index-basename=s',
-    'date-separator=s',
     'timezone=s',
     'skip-alias=s@',
     # Basic options

--- a/scripts/es-graphite-dynamic.pl
+++ b/scripts/es-graphite-dynamic.pl
@@ -73,7 +73,6 @@ if( exists $cfg{'carbon-server'} and length $cfg{'carbon-server'} ) {
 
 #------------------------------------------------------------------------#
 # Collect and Decode the Cluster Statistics
-
 my @metrics = sort map { "$_->{key} $_->{value}" } @{ $Fetcher->get_metrics };
 if( !@metrics ) {
     output({color=>'red'}, "Error retrieving metrics");

--- a/t/02-index-data.t
+++ b/t/02-index-data.t
@@ -16,7 +16,18 @@ $Data::Dumper::Sortkeys = 1;
 my $now = DateTime->now();
 my @days_old = qw(0 1 3 5 8 13 21 90);
 
-my %TESTS=();
+my %TESTS=(
+    'notadate-100000' => {
+            es_index_bases      => 'notadate',
+            es_index_days_old   => undef,
+            es_index_strip_date => 'notadate-100000',
+    },
+    strftime('mystery-science-theater-3000-%Y.%m.%d', localtime) => {
+            es_index_bases      => 'mystery,mystery-science,mystery-science-theater',
+            es_index_days_old   => 0,
+            es_index_strip_date => 'mystery-science-theater-3000',
+    },
+);
 foreach my $days_old ( @days_old ) {
     # Query String Parser Testing
     my $lt = $now->clone->subtract( days => $days_old );
@@ -37,6 +48,11 @@ foreach my $days_old ( @days_old ) {
             es_index_days_old   => $days_old,
             es_index_strip_date => 'type_dcid',
         },
+        "type_dcid_$date-0001" => {
+            es_index_bases      => 'type,type_dcid',
+            es_index_days_old   => $days_old,
+            es_index_strip_date => 'type_dcid',
+        },
     );
     # Install the test globally
     foreach my $t (keys %tests) {
@@ -50,7 +66,7 @@ foreach my $t (sort keys %TESTS) {
     my $got = {
         es_index_bases      => join(',', es_index_bases($t)),
         es_index_strip_date => es_index_strip_date($t),
-        es_index_days_old   => es_index_days_old($t),
+        es_index_days_old   => es_index_days_old($t) // undef,
     };
     is_deeply($got,$TESTS{$t},sprintf "%s - %s", $t, join(',', sort keys %{$got})) or diag( Dumper $got );
 }


### PR DESCRIPTION
* Remove the `--date-sep` logic and auto-detect dates in indexes
* Intelligent metrics reporting based on node roles in `App::ElasticSearch::Utilities::Metrics`
* Add explicit `return`s in a few places and update the devtools